### PR TITLE
Refactor Label Settings

### DIFF
--- a/backend/server/core/k8s_app.py
+++ b/backend/server/core/k8s_app.py
@@ -99,7 +99,7 @@ class K8sApp:
 
     @staticmethod
     def get_labels() -> Set:
-        return set([label.get("name") for label in settings.k8s.labels])
+        return set(settings.k8s.labels)
 
     @staticmethod
     def parse_input_topics(input_topics: str) -> List[str]:

--- a/backend/settings.yaml
+++ b/backend/settings.yaml
@@ -19,7 +19,7 @@ k8s:
       key: "metadata.labels"
   labels:
     # used to set attributes of nodes in the graph (used to extract pipeline names)
-    - name: "pipeline"
+    - "pipeline"
   independent_graph:
     # refers to the attribute of nodes the pipeline name should be extracted from
     label: "pipeline"


### PR DESCRIPTION
Makes configuration with Env Variables easier:
`SE_K8S__labels=['label'] `
instead of defining a list of dicts.
