### PR TITLE
Fullscreen graph & handle window resizing

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,9 +20,9 @@
     "http-proxy-middleware": "^1.0.5",
     "millify": "^3.5.0",
     "react": "^16.13.1",
-    "react-cool-dimensions": "^1.1.3",
     "react-dom": "^16.13.1",
     "react-json-view": "^1.19.1",
+    "react-resize-detector": "^6.5.0",
     "react-scripts": "^3.4.3",
     "restful-react": "^14.4.0",
     "typescript": "^3.7.5"

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,6 @@
 .application {
   text-align: center;
-  background: rgba(0, 0, 0, 0.05);
+  background: #f0f2f5;
   border-radius: 4px;
 }
 

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,5 @@
 body {
-  background: #f0f2f5;
+  background-color: #f0f2f5 !important;
 }
 
 .application {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,6 +1,9 @@
+body {
+  background: #f0f2f5;
+}
+
 .application {
   text-align: center;
-  background: #f0f2f5;
   border-radius: 4px;
 }
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -2,6 +2,11 @@ import React from "react";
 import ReactDOM from "react-dom";
 import App from "./App";
 
+(window as any).ResizeObserver = class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+};
+
 it("renders without crashing", () => {
   const div = document.createElement("div");
   ReactDOM.render(<App />, div);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -153,8 +153,7 @@ const App: React.FC = () => {
             style={{
               minHeight: "100vh",
               paddingTop: "64px",
-              // overflow: "auto",
-              // position: "fixed",
+              position: "relative",
             }}
           >
             <Row>
@@ -175,23 +174,17 @@ const App: React.FC = () => {
                   showIcon
                 />
               )}
-            </Row>
-            <Row
-              style={{
-                position: "fixed",
-                top: "66%",
-                padding: "0 50px",
-                // top: 0,
-                // bottom: 0,
-                // left: 0,
-                // right: 0,
-                width: width,
-                zIndex: 999,
-                maxHeight: "100%",
-                overflowY: "auto",
-              }}
-            >
-              <DetailsCard nodeID={selectedNodeID} />
+              <Row
+                style={{
+                  padding: "0 50px",
+                  width: width,
+                  zIndex: 999,
+                  top: "66%",
+                  position: "absolute",
+                }}
+              >
+                <DetailsCard nodeID={selectedNodeID} />
+              </Row>
             </Row>
           </Content>
         </Layout>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -159,7 +159,7 @@ const App: React.FC = () => {
                   refetchMetrics={() => refetchMetrics()}
                   onClickNode={(nodeId: string) => setSelectedNodeID(nodeId)}
                   width={width}
-                  height={height}
+                  height={height - 64}
                   window={window}
                 />
               ) : (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,10 +82,11 @@ const App: React.FC = () => {
     message.error(pipelineError?.message);
   }
 
-  graphConfig.height =
-    height > window.screen.height
-      ? window.screen.height * 0.66 - 64
-      : height * 0.66 - 64;
+  // graphConfig.height =
+  //   height > window.screen.height
+  //     ? window.screen.height * 0.66 - 64
+  //     : height * 0.66 - 64;
+  graphConfig.height = height - 64;
   graphConfig.width = width;
 
   const menuPipeline = (
@@ -148,7 +149,13 @@ const App: React.FC = () => {
               </Menu.Item>
             </Menu>
           </Header>
-          <Content style={{ minHeight: "100vh", paddingTop: "64px" }}>
+          <Content
+            style={{
+              minHeight: "100vh",
+              paddingTop: "64px",
+              overflow: "hidden",
+            }}
+          >
             <Row>
               {graph ? (
                 <GraphVisualization
@@ -168,7 +175,18 @@ const App: React.FC = () => {
                 />
               )}
             </Row>
-            <Row style={{ padding: "0 50px", width: width }}>
+            <Row
+              style={{
+                position: "fixed",
+                overflow: "scroll",
+                top: "66%",
+                padding: "0 50px",
+                width: width,
+                minHeight: "200px",
+                // height: "33%",
+                zIndex: 999,
+              }}
+            >
               <DetailsCard nodeID={selectedNodeID} />
             </Row>
           </Content>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect, useCallback } from "react";
 import "./App.css";
-import useDimensions from "react-cool-dimensions";
+import { useResizeDetector } from "react-resize-detector";
 import {
   usePipelinesApiPipelinesGet,
   useGraphPositionedApiGraphGet,
@@ -29,7 +29,13 @@ const App: React.FC = () => {
   const [currentPipeline, setCurrentPipeline] = useState(ALL_PIPELINES);
   const [selectedNodeID, setSelectedNodeID] = useState<string | null>(null);
   const ref = useRef<HTMLDivElement>(null!);
-  const { width, height } = useDimensions({ ref });
+  const onResize = useCallback(() => {}, []);
+  const { width, height } = useResizeDetector({
+    targetRef: ref,
+    refreshMode: "debounce",
+    refreshRate: 100,
+    onResize,
+  });
   const defaultRefreshInterval = 30;
   const refreshIntervals: Record<number, string> = {
     0: "off",
@@ -159,8 +165,7 @@ const App: React.FC = () => {
                   refetchMetrics={() => refetchMetrics()}
                   onClickNode={(nodeId: string) => setSelectedNodeID(nodeId)}
                   width={width}
-                  height={height - 64}
-                  window={window}
+                  height={height! - 64}
                 />
               ) : (
                 <Alert
@@ -176,7 +181,7 @@ const App: React.FC = () => {
                 padding: "0 50px",
                 width: width,
                 zIndex: 1,
-                top: height - 147,
+                top: height! - 147,
                 position: "absolute",
               }}
             >

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -82,13 +82,6 @@ const App: React.FC = () => {
     message.error(pipelineError?.message);
   }
 
-  // graphConfig.height =
-  //   height > window.screen.height
-  //     ? window.screen.height * 0.66 - 64
-  //     : height * 0.66 - 64;
-  graphConfig.height = height - 64;
-  graphConfig.width = width;
-
   const menuPipeline = (
     <Menu
       onClick={(e) => {
@@ -165,6 +158,9 @@ const App: React.FC = () => {
                   metrics={metrics}
                   refetchMetrics={() => refetchMetrics()}
                   onClickNode={(nodeId: string) => setSelectedNodeID(nodeId)}
+                  width={width}
+                  height={height}
+                  window={window}
                 />
               ) : (
                 <Alert
@@ -180,7 +176,7 @@ const App: React.FC = () => {
                 padding: "0 50px",
                 width: width,
                 zIndex: 1,
-                top: "85%",
+                top: height - 150,
                 position: "absolute",
                 background: "#F0F2F5",
               }}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -176,7 +176,7 @@ const App: React.FC = () => {
                 padding: "0 50px",
                 width: width,
                 zIndex: 1,
-                top: height - 150,
+                top: height - 147,
                 position: "absolute",
               }}
             >

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -178,7 +178,6 @@ const App: React.FC = () => {
                 zIndex: 1,
                 top: height - 150,
                 position: "absolute",
-                background: "#F0F2F5",
               }}
             >
               <DetailsCard nodeID={selectedNodeID} />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -120,7 +120,7 @@ const App: React.FC = () => {
     return (
       <div ref={ref} className="application">
         <Layout className="layout">
-          <Header className="header">
+          <Header className="header" style={{ zIndex: 2 }}>
             <Menu theme="dark" mode="horizontal" selectable={false}>
               <Menu.Item key="1">
                 Pipeline:&nbsp;
@@ -156,7 +156,7 @@ const App: React.FC = () => {
               position: "relative",
             }}
           >
-            <Row>
+            <Row style={{ position: "fixed" }}>
               {graph ? (
                 <GraphVisualization
                   id="topology-graph"
@@ -174,17 +174,18 @@ const App: React.FC = () => {
                   showIcon
                 />
               )}
-              <Row
-                style={{
-                  padding: "0 50px",
-                  width: width,
-                  zIndex: 999,
-                  top: "66%",
-                  position: "absolute",
-                }}
-              >
-                <DetailsCard nodeID={selectedNodeID} />
-              </Row>
+            </Row>
+            <Row
+              style={{
+                padding: "0 50px",
+                width: width,
+                zIndex: 1,
+                top: "85%",
+                position: "absolute",
+                background: "#F0F2F5",
+              }}
+            >
+              <DetailsCard nodeID={selectedNodeID} />
             </Row>
           </Content>
         </Layout>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -153,7 +153,8 @@ const App: React.FC = () => {
             style={{
               minHeight: "100vh",
               paddingTop: "64px",
-              overflow: "hidden",
+              // overflow: "auto",
+              // position: "fixed",
             }}
           >
             <Row>
@@ -178,13 +179,16 @@ const App: React.FC = () => {
             <Row
               style={{
                 position: "fixed",
-                overflow: "scroll",
                 top: "66%",
                 padding: "0 50px",
+                // top: 0,
+                // bottom: 0,
+                // left: 0,
+                // right: 0,
                 width: width,
-                minHeight: "200px",
-                // height: "33%",
                 zIndex: 999,
+                maxHeight: "100%",
+                overflowY: "auto",
               }}
             >
               <DetailsCard nodeID={selectedNodeID} />

--- a/frontend/src/components/Details.tsx
+++ b/frontend/src/components/Details.tsx
@@ -106,7 +106,7 @@ const LinkInfo = ({ infoListItem, nodeID }: NodeInfoDetailProps) => {
       </Space>
     );
   }
-  return <>"Could not get link to service"</>;
+  return <>Could not get link to service</>;
 };
 
 export default Details;

--- a/frontend/src/components/DetailsCard.tsx
+++ b/frontend/src/components/DetailsCard.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from "react";
 import { Card } from "antd";
-import useDimensions from "react-cool-dimensions";
+import { useResizeDetector } from "react-resize-detector";
 import Details from "./Details";
 import "./Details.css";
 
@@ -10,7 +10,7 @@ interface DetailsCardProps {
 
 const DetailsCard = ({ nodeID }: DetailsCardProps) => {
   const ref = useRef<HTMLDivElement>(null!);
-  const { width } = useDimensions({ ref });
+  const { width } = useResizeDetector({ targetRef: ref, handleHeight: false });
   return (
     <div ref={ref} className="details">
       <Card

--- a/frontend/src/components/GraphVisualization.tsx
+++ b/frontend/src/components/GraphVisualization.tsx
@@ -20,6 +20,9 @@ interface GraphVisualizationProps {
   metrics: Metric[] | null;
   refetchMetrics: Function;
   onClickNode: Function;
+  window: Window;
+  width: number;
+  height: number;
 }
 
 class Icon implements IIcon {
@@ -89,6 +92,9 @@ const GraphVisualization = ({
   metrics,
   refetchMetrics,
   onClickNode,
+  width,
+  height,
+  window,
 }: GraphVisualizationProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
@@ -136,6 +142,11 @@ const GraphVisualization = ({
     [onClickNode]
   );
 
+  window.onresize = () => {
+    if (!graph || graph.get("destroyed")) return;
+    graph.changeSize(width, height - 64);
+  };
+
   useEffect(() => {
     config.container = ReactDOM.findDOMNode(ref.current) as HTMLElement;
     let currentGraph: Graph | null = graph;
@@ -144,6 +155,7 @@ const GraphVisualization = ({
     }
     let nodes = data["nodes"];
     const defaultIconConfig = config?.defaultNode?.icon as NodeConfig["icon"];
+    currentGraph?.changeSize(width, height);
 
     nodes?.forEach((node: any) => {
       if (!node.icon) {

--- a/frontend/src/components/GraphVisualization.tsx
+++ b/frontend/src/components/GraphVisualization.tsx
@@ -144,18 +144,19 @@ const GraphVisualization = ({
 
   window.onresize = () => {
     if (!graph || graph.get("destroyed")) return;
-    graph.changeSize(width, height - 64);
+    graph.changeSize(width, height);
   };
 
   useEffect(() => {
     config.container = ReactDOM.findDOMNode(ref.current) as HTMLElement;
     let currentGraph: Graph | null = graph;
     if (!currentGraph && ref) {
+      config.width = width;
+      config.height = height;
       currentGraph = new G6.Graph(config);
     }
     let nodes = data["nodes"];
     const defaultIconConfig = config?.defaultNode?.icon as NodeConfig["icon"];
-    currentGraph?.changeSize(width, height);
 
     nodes?.forEach((node: any) => {
       if (!node.icon) {

--- a/frontend/src/components/GraphVisualization.tsx
+++ b/frontend/src/components/GraphVisualization.tsx
@@ -20,9 +20,8 @@ interface GraphVisualizationProps {
   metrics: Metric[] | null;
   refetchMetrics: Function;
   onClickNode: Function;
-  window: Window;
-  width: number;
-  height: number;
+  width: number | undefined;
+  height: number | undefined;
 }
 
 class Icon implements IIcon {
@@ -94,11 +93,13 @@ const GraphVisualization = ({
   onClickNode,
   width,
   height,
-  window,
 }: GraphVisualizationProps) => {
   const ref = useRef<HTMLDivElement>(null);
 
   const [graph, setGraph] = useState<Graph | null>(null);
+  if (graph && width && height) {
+    graph.changeSize(width, height);
+  }
 
   if (graph && metrics) {
     updateNodeMetrics(graph, metrics);
@@ -142,17 +143,10 @@ const GraphVisualization = ({
     [onClickNode]
   );
 
-  window.onresize = () => {
-    if (!graph || graph.get("destroyed")) return;
-    graph.changeSize(width, height);
-  };
-
   useEffect(() => {
     config.container = ReactDOM.findDOMNode(ref.current) as HTMLElement;
     let currentGraph: Graph | null = graph;
     if (!currentGraph && ref) {
-      config.width = width;
-      config.height = height;
       currentGraph = new G6.Graph(config);
     }
     let nodes = data["nodes"];


### PR DESCRIPTION
Closes #44 #47 
Always render graph fullscreen, dynamically adjust dimensions when window is resized (including window events such as going fullscreen). 
Details view is now an overlay card taking up less space by default. When scrolling it moves over the graph area to reveal all the information. 