### PR TITLE
draft: configmap based discovery

### DIFF
--- a/backend/streams_explorer/streams_explorer.py
+++ b/backend/streams_explorer/streams_explorer.py
@@ -127,6 +127,8 @@ class StreamsExplorer:
 
         self.k8s_app_client = kubernetes.client.AppsV1Api()
         self.k8s_batch_client = kubernetes.client.BatchV1beta1Api()
+        self.k8s_core_client = kubernetes.client.CoreV1Api()
+
 
     def __retrieve_deployments(self):
         items = self.get_deployments() + self.get_stateful_sets() + self.get_configmaps()
@@ -151,7 +153,7 @@ class StreamsExplorer:
         configmaps: List[V1ConfigMap] = []
         for namespace in self.namespaces:
             logger.info(f"List configmaps in namespace {namespace}")
-            configmaps += self.k8s_app_client.list_namespaced_config_map(
+            configmaps += self.k8s_core_client.list_namespaced_config_map(
                 namespace=namespace, watch=False
             ).items
         return configmaps

--- a/backend/streams_explorer/streams_explorer.py
+++ b/backend/streams_explorer/streams_explorer.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional, Type
 
 import kubernetes
-from kubernetes.client import V1beta1CronJob, V1Deployment, V1StatefulSet
+from kubernetes.client import V1beta1CronJob, V1Deployment, V1StatefulSet, V1ConfigMap
 from loguru import logger
 
 from streams_explorer.core.config import settings
@@ -129,7 +129,7 @@ class StreamsExplorer:
         self.k8s_batch_client = kubernetes.client.BatchV1beta1Api()
 
     def __retrieve_deployments(self):
-        items = self.get_deployments() + self.get_stateful_sets()
+        items = self.get_deployments() + self.get_stateful_sets() + self.get_configmaps()
         for item in items:
             try:
                 app = K8sApp.factory(item)
@@ -146,6 +146,17 @@ class StreamsExplorer:
                 namespace=namespace, watch=False
             ).items
         return deployments
+
+    def get_configmaps(self) -> List[V1ConfigMap]:
+        configmaps: List[V1ConfigMap] = []
+        for namespace in self.namespaces:
+            logger.info(f"List configmaps in namespace {namespace}")
+            configmaps += self.k8s_app_client.list_namespaced_config_map(
+                namespace=namespace, watch=False
+            ).items
+        return configmaps
+
+
 
     def get_stateful_sets(self) -> List[V1StatefulSet]:
         stateful_sets: List[V1StatefulSet] = []

--- a/backend/tests/utils.py
+++ b/backend/tests/utils.py
@@ -10,6 +10,7 @@ from kubernetes.client import (
     V1PodTemplateSpec,
     V1StatefulSet,
     V1StatefulSetSpec,
+    V1ConfigMap
 )
 
 
@@ -39,6 +40,32 @@ def get_streaming_app_deployment(
     metadata = get_metadata(name, pipeline=pipeline)
     return V1Deployment(metadata=metadata, spec=spec)
 
+def get_streaming_app_configmap(
+        name,
+        input_topics,
+        output_topic,
+        error_topic,
+        multiple_inputs=None,
+        multiple_outputs=None,
+        env_prefix="APP_",
+        pipeline=None,
+        consumer_group=None,
+) -> V1ConfigMap:
+
+
+    data = {env_prefix + "INPUT_TOPICS" : input_topics,
+            env_prefix + "OUTPUT_TOPIC" : output_topic,
+            env_prefix + "ERROR_TOPIC" : error_topic,
+            "ENV_PREFIX" : env_prefix}
+
+    if multiple_inputs:
+        data[env_prefix + "EXTRA_INPUT_TOPICS"]= multiple_inputs
+
+    if multiple_outputs:
+        data[env_prefix + "EXTRA_OUTPUT_TOPICS"]= multiple_outputs
+
+    metadata = get_metadata(name, pipeline=pipeline, group=consumer_group)
+    return V1ConfigMap(metadata=metadata, data=data)
 
 def get_streaming_app_stateful_set(
     name,
@@ -71,10 +98,11 @@ def get_streaming_app_stateful_set(
     return V1StatefulSet(metadata=metadata, spec=spec)
 
 
-def get_metadata(name, pipeline=None) -> V1ObjectMeta:
+def get_metadata(name, pipeline=None, group="defaultGroup") -> V1ObjectMeta:
     return V1ObjectMeta(
         annotations={
             "deployment.kubernetes.io/revision": "1",
+            "consumerGroup": group,
         },
         labels={
             "app": name,


### PR DESCRIPTION
it essentially uses the same pattern as for sts and deployment discovery. 

I recall you pointing me to using extractors instead, but this somewhat more tangible for us.

our case looks like:
A little operator finds kafka apps, calls their topology endpoint, generates configmaps as assumed in this PR, which in turn will be picked up by streams-explorer.