### PR TITLE
Build independent pipelines from label

### DIFF
--- a/backend/settings.yaml
+++ b/backend/settings.yaml
@@ -26,7 +26,7 @@ k8s:
   labels:
     # used to set attributes of nodes in the graph (used to extract pipeline names)
     - "pipeline"
-  independent_graph:
+  pipeline:
     # refers to the attribute of nodes the pipeline name should be extracted from
     label: "pipeline"
 

--- a/backend/streams_explorer/core/config.py
+++ b/backend/streams_explorer/core/config.py
@@ -17,7 +17,7 @@ settings = Dynaconf(
         Validator("k8s.deployment.namespaces", must_exist=True, is_type_of=list),
         Validator("k8s.containers.ignore", is_type_of=list),
         Validator("k8s.labels", must_exist=True, is_type_of=list),
-        Validator("k8s.pipeline", must_exist=True, is_type_of=dict),
+        Validator("k8s.pipeline.label", must_exist=True, is_type_of=str),
         Validator("schemaregistry.url", must_exist=True, is_type_of=str),
         Validator("prometheus.url", must_exist=True, is_type_of=str),
         Validator("plugins.path", must_exist=True, is_type_of=str),

--- a/backend/streams_explorer/core/config.py
+++ b/backend/streams_explorer/core/config.py
@@ -17,7 +17,7 @@ settings = Dynaconf(
         Validator("k8s.deployment.namespaces", must_exist=True, is_type_of=list),
         Validator("k8s.containers.ignore", is_type_of=list),
         Validator("k8s.labels", must_exist=True, is_type_of=list),
-        Validator("k8s.independent_graph", must_exist=True, is_type_of=dict),
+        Validator("k8s.pipeline", must_exist=True, is_type_of=dict),
         Validator("schemaregistry.url", must_exist=True, is_type_of=str),
         Validator("prometheus.url", must_exist=True, is_type_of=str),
         Validator("plugins.path", must_exist=True, is_type_of=str),

--- a/backend/streams_explorer/core/k8s_app.py
+++ b/backend/streams_explorer/core/k8s_app.py
@@ -47,8 +47,7 @@ class K8sApp:
         return name
 
     def get_pipeline(self) -> Optional[str]:
-        if settings.k8s.pipeline and settings.k8s.pipeline.label is not None:
-            return self.attributes.get(settings.k8s.pipeline.label)
+        return self.attributes.get(settings.k8s.pipeline.label)
 
     def __get_common_configuration(self):
         for env in self.container.env:
@@ -90,6 +89,10 @@ class K8sApp:
                 logger.warning(
                     f"{self.get_class_name()} {self.name} does not have a label with the name: {key}"
                 )
+
+        pipeline = self.get_pipeline()
+        if pipeline is not None:
+            self.attributes["pipeline"] = pipeline
 
         if (
             self.k8s_object.spec.template.metadata

--- a/backend/streams_explorer/core/k8s_app.py
+++ b/backend/streams_explorer/core/k8s_app.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional, Set, Union
 
 from kubernetes.client import (
     V1beta1CronJob,
@@ -15,9 +15,11 @@ from loguru import logger
 from streams_explorer.core.config import settings
 from streams_explorer.extractors import extractor_container
 
+K8sObject = Union[V1Deployment, V1StatefulSet, V1beta1CronJob]
+
 
 class K8sApp:
-    def __init__(self, k8s_object):
+    def __init__(self, k8s_object: K8sObject):
         self.k8s_object = k8s_object
         self.metadata: Optional[V1ObjectMeta] = k8s_object.metadata
         self.name: str = self.get_name()
@@ -47,7 +49,7 @@ class K8sApp:
         return name
 
     def get_pipeline(self) -> Optional[str]:
-        return self.attributes.get(settings.k8s.pipeline.label)
+        return self.attributes.get(settings.k8s.pipeline.label)  # type: ignore
 
     def __get_common_configuration(self):
         for env in self.container.env:
@@ -102,7 +104,7 @@ class K8sApp:
             self.attributes.update(annotations)
 
     @staticmethod
-    def factory(k8s_object: object) -> K8sApp:
+    def factory(k8s_object: K8sObject) -> K8sApp:
         if isinstance(k8s_object, V1Deployment):
             return K8sAppDeployment(k8s_object)
         elif isinstance(k8s_object, V1StatefulSet):

--- a/backend/streams_explorer/core/k8s_app.py
+++ b/backend/streams_explorer/core/k8s_app.py
@@ -46,6 +46,10 @@ class K8sApp:
             raise TypeError(f"Name is required for {self.get_class_name()}")
         return name
 
+    def get_pipeline(self) -> Optional[str]:
+        if settings.k8s.pipeline and settings.k8s.pipeline.label is not None:
+            return self.attributes.get(settings.k8s.pipeline.label)
+
     def __get_common_configuration(self):
         for env in self.container.env:
             name = env.name

--- a/backend/streams_explorer/core/k8s_app.py
+++ b/backend/streams_explorer/core/k8s_app.py
@@ -15,6 +15,8 @@ from loguru import logger
 from streams_explorer.core.config import settings
 from streams_explorer.extractors import extractor_container
 
+ATTR_PIPELINE = "pipeline"
+
 K8sObject = Union[V1Deployment, V1StatefulSet, V1beta1CronJob]
 
 
@@ -94,7 +96,7 @@ class K8sApp:
 
         pipeline = self.get_pipeline()
         if pipeline is not None:
-            self.attributes["pipeline"] = pipeline
+            self.attributes[ATTR_PIPELINE] = pipeline
 
         if (
             self.k8s_object.spec.template.metadata

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Type
+from typing import Dict, List, Type
 
 import networkx as nx
 from loguru import logger
@@ -6,7 +6,7 @@ from networkx.drawing.nx_agraph import graphviz_layout
 from networkx.generators.ego import ego_graph
 
 from streams_explorer.core.config import settings
-from streams_explorer.core.k8s_app import K8sApp
+from streams_explorer.core.k8s_app import ATTR_PIPELINE, K8sApp
 from streams_explorer.core.services.metric_providers import MetricProvider
 from streams_explorer.models.graph import Metric
 from streams_explorer.models.kafka_connector import (
@@ -29,7 +29,7 @@ class DataFlowGraph:
         self.metric_provider_class = metric_provider
 
     def add_streaming_app(self, app: K8sApp):
-        pipeline = app.attributes.get("pipeline")
+        pipeline = app.attributes.get(ATTR_PIPELINE)
 
         self._add_streaming_app(self.graph, app)
         if pipeline:
@@ -111,11 +111,11 @@ class DataFlowGraph:
         except KeyError:
             raise NodeNotFound()
 
-    def assign_pipeline(self, node_name: str) -> Optional[str]:
+    def assign_pipeline(self, node_name: str):
         neighborhood = ego_graph(self.graph, node_name, radius=3, undirected=True)
         pipeline = None
         for _, node in neighborhood.nodes(data=True):
-            pipeline = node.get("pipeline")
+            pipeline = node.get(ATTR_PIPELINE)
             if pipeline is not None:
                 logger.debug("Pipeline found for {}: {}", node_name, pipeline)
                 self.pipelines[pipeline].update(

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -116,14 +116,13 @@ class DataFlowGraph:
             neighborhood = ego_graph(
                 undirected_graph, connector, radius=2, undirected=True
             ).nodes(data=True)
-            for node in neighborhood:
-                pipeline = node[1].get("pipeline")
+            for _, node in neighborhood:
+                pipeline = node.get("pipeline")
                 if pipeline is not None:
                     logger.debug(
                         "Pipeline found for connector {}: {}", connector, pipeline
                     )
-                    for n in neighborhood:
-                        pipeline_nodes[pipeline].append(n)
+                    pipeline_nodes[pipeline].extend(neighborhood)
                     break
 
         # build pipeline graphs
@@ -187,7 +186,6 @@ class DataFlowGraph:
     @staticmethod
     def __filter_connectors(node: Tuple[str, dict]) -> bool:
         return node[1]["node_type"] == NodeTypesEnum.CONNECTOR
-        # [node for node in self.graph.nodes(data=True) if node[1]["node_type"] == NodeTypesEnum.CONNECTOR]
 
     @staticmethod
     def __get_json_graph(graph: nx.Graph) -> dict:

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -34,7 +34,6 @@ class DataFlowGraph:
             app.name,
             label=app.name,
             node_type=NodeTypesEnum.STREAMING_APP,
-            pipeline=pipeline,
             **app.attributes,
         )
         if app.output_topic:

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -28,14 +28,13 @@ class DataFlowGraph:
         self.metric_provider_class = metric_provider
 
     def add_streaming_app(self, app: K8sApp):
-        pipeline = app.get_pipeline()
-
         self.graph.add_node(
             app.name,
             label=app.name,
             node_type=NodeTypesEnum.STREAMING_APP,
             **app.attributes,
         )
+        pipeline = app.attributes.get("pipeline")
         if app.output_topic:
             self._add_topic(app.output_topic, pipeline)
             self._add_output_topic(app.name, app.output_topic, pipeline)

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Tuple, Type
+from typing import Dict, List, Optional, Tuple, Type, cast
 
 import networkx as nx
 from networkx.drawing.nx_agraph import graphviz_layout
@@ -104,7 +104,7 @@ class DataFlowGraph:
             pipeline_name = self.__extract_pipeline_name(pipeline_graph)
             existing_graph: Optional[nx.DiGraph] = self.pipelines.get(pipeline_name)
             if existing_graph is not None:
-                graph = existing_graph.copy()
+                graph = cast(nx.DiGraph, existing_graph.copy())
                 graph.update(
                     edges=pipeline_graph.edges(data=True),
                     nodes=pipeline_graph.nodes(data=True),

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -126,10 +126,12 @@ class DataFlowGraph:
         if pipeline is None:
             logger.warning("No pipeline found for {}", node_name)
 
-    def _add_topic(self, graph: nx.DiGraph, name: str):
+    @staticmethod
+    def _add_topic(graph: nx.DiGraph, name: str):
         graph.add_node(name, label=name, node_type=NodeTypesEnum.TOPIC)
 
-    def _add_input_topic(self, graph: nx.DiGraph, streaming_app: str, topic_name: str):
+    @staticmethod
+    def _add_input_topic(graph: nx.DiGraph, streaming_app: str, topic_name: str):
         graph.add_edge(topic_name, streaming_app)
 
     def _add_output_topic(
@@ -141,8 +143,8 @@ class DataFlowGraph:
         self._add_topic(graph, topic_name)
         graph.add_edge(streaming_app, topic_name)
 
+    @staticmethod
     def _add_error_topic(
-        self,
         graph: nx.DiGraph,
         streaming_app: str,
         topic_name: str,

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -112,7 +112,9 @@ class DataFlowGraph:
             pipeline_nodes[current_node[1]["pipeline"]].append(current_node)
 
         # assign pipeline for nodes without label
-        for connector, _ in list(filter(self.__filter_connectors, nodes)):
+        for connector, _ in list(
+            filter(lambda node: not self.__filter_pipeline_nodes(node), nodes)
+        ):
             neighborhood = ego_graph(
                 undirected_graph, connector, radius=3, undirected=True
             ).nodes(data=True)
@@ -178,10 +180,6 @@ class DataFlowGraph:
     @staticmethod
     def __filter_pipeline_nodes(node: Tuple[str, dict]) -> bool:
         return node[1].get("pipeline") is not None
-
-    @staticmethod
-    def __filter_connectors(node: Tuple[str, dict]) -> bool:
-        return node[1].get("pipeline") is None
 
     @staticmethod
     def __filter_pipeline_edges(edge: Tuple[str, str], nodes: List[str]) -> bool:

--- a/backend/streams_explorer/streams_explorer.py
+++ b/backend/streams_explorer/streams_explorer.py
@@ -56,7 +56,7 @@ class StreamsExplorer:
         return self.data_flow.get_positioned_pipeline_graph(pipeline_name)
 
     def get_pipeline_names(self) -> List[str]:
-        return list(self.data_flow.independent_graphs.keys())
+        return list(self.data_flow.pipelines.keys())
 
     def get_metrics(self) -> List:
         return self.data_flow.get_metrics()

--- a/backend/streams_explorer/streams_explorer.py
+++ b/backend/streams_explorer/streams_explorer.py
@@ -193,5 +193,5 @@ class StreamsExplorer:
             self.data_flow.add_sink(sink)
 
         # extract subgraphs
-        logger.info("Extract independent pipelines")
-        self.data_flow.extract_independent_pipelines()
+        # logger.info("Extract independent pipelines")
+        # self.data_flow.extract_independent_pipelines()

--- a/backend/streams_explorer/streams_explorer.py
+++ b/backend/streams_explorer/streams_explorer.py
@@ -5,7 +5,7 @@ from kubernetes.client import V1beta1CronJob, V1Deployment, V1StatefulSet
 from loguru import logger
 
 from streams_explorer.core.config import settings
-from streams_explorer.core.k8s_app import K8sApp
+from streams_explorer.core.k8s_app import K8sApp, K8sObject
 from streams_explorer.core.node_info_extractor import (
     get_displayed_information_connector,
     get_displayed_information_deployment,
@@ -129,7 +129,9 @@ class StreamsExplorer:
         self.k8s_batch_client = kubernetes.client.BatchV1beta1Api()
 
     def __retrieve_deployments(self):
-        items = self.get_deployments() + self.get_stateful_sets()
+        items: List[K8sObject] = []
+        items += self.get_deployments()
+        items += self.get_stateful_sets()
         for item in items:
             try:
                 app = K8sApp.factory(item)
@@ -191,7 +193,3 @@ class StreamsExplorer:
 
         for sink in sinks:
             self.data_flow.add_sink(sink)
-
-        # extract subgraphs
-        # logger.info("Extract independent pipelines")
-        # self.data_flow.extract_independent_pipelines()

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -122,7 +122,7 @@ class TestDataFlowGraph:
         assert df.graph.nodes["test-app2"].get("pipeline") is None
 
     def test_extract_independent_pipelines(self, df: DataFlowGraph):
-        settings.k8s.independent_graph.label = "pipeline"
+        settings.k8s.pipeline.label = "pipeline"
         df.add_streaming_app(self.get_k8s_app())
         df.add_streaming_app(
             self.get_k8s_app(
@@ -134,12 +134,12 @@ class TestDataFlowGraph:
             )
         )
         df.extract_independent_pipelines()
-        assert "test-app" in df.independent_graphs
-        assert "pipeline2" in df.independent_graphs
+        assert "test-app" in df.pipelines
+        assert "pipeline2" in df.pipelines
 
         df.graph.add_node("test-node")
         df.extract_independent_pipelines()
-        assert "test-node" in df.independent_graphs
+        assert "test-node" in df.pipelines
 
     @staticmethod
     def get_k8s_app(

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -123,7 +123,7 @@ class TestDataFlowGraph:
 
     def test_extract_independent_pipelines(self, df: DataFlowGraph):
         settings.k8s.pipeline.label = "pipeline"
-        df.add_streaming_app(self.get_k8s_app())
+        df.add_streaming_app(self.get_k8s_app(pipeline="pipeline1"))
         df.add_streaming_app(
             self.get_k8s_app(
                 name="type2-app2",
@@ -134,12 +134,14 @@ class TestDataFlowGraph:
             )
         )
         df.extract_independent_pipelines()
-        assert "test-app" in df.pipelines
+        assert "pipeline1" in df.pipelines
         assert "pipeline2" in df.pipelines
+        assert len(df.pipelines) == 2
 
         df.graph.add_node("test-node")
         df.extract_independent_pipelines()
-        assert "test-node" in df.pipelines
+        assert "test-node" not in df.pipelines
+        assert len(df.pipelines) == 2
 
     @staticmethod
     def get_k8s_app(

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -142,10 +142,19 @@ class TestDataFlowGraph:
         assert "pipeline2" in df.pipelines
         pipeline1 = df.pipelines["pipeline1"]
         pipeline2 = df.pipelines["pipeline2"]
-        assert len(pipeline1.nodes) == 4
-        assert len(pipeline2.nodes) == 5
-        assert "output-topic" in pipeline1.nodes
-        assert "output-topic" in pipeline2.nodes
+        assert set(pipeline1.nodes) == {
+            "input-topic",
+            "output-topic",
+            "test-app",
+            "error-topic",
+        }
+        assert set(pipeline2.nodes) == {
+            "output-topic",
+            "input-topic2",
+            "output-topic2",
+            "test-app2",
+            "error-topic2",
+        }
 
         df.add_sink(Sink("test-sink", "output-topic"))
         assert "test-sink" in pipeline1.nodes

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -138,11 +138,6 @@ class TestDataFlowGraph:
         assert "pipeline2" in df.pipelines
         assert len(df.pipelines) == 2
 
-        df.graph.add_node("test-node")
-        df.extract_independent_pipelines()
-        assert "test-node" not in df.pipelines
-        assert len(df.pipelines) == 2
-
     @staticmethod
     def get_k8s_app(
         name="test-app",

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -82,6 +82,7 @@ class TestDataFlowGraph:
         df.add_source(source)
         assert len(df.graph.nodes) == 5
         assert df.graph.has_edge("test-source", "test-app")
+        assert len(df.pipelines) == 0
 
     def test_add_sink(self, df: DataFlowGraph):
         sink = Sink(
@@ -93,6 +94,7 @@ class TestDataFlowGraph:
         df.add_sink(sink)
         assert len(df.graph.nodes) == 5
         assert df.graph.has_edge("test-app", "test-sink")
+        assert len(df.pipelines) == 0
 
     def test_get_positioned_json_graph(self, df: DataFlowGraph):
         df.add_streaming_app(self.get_k8s_app())
@@ -138,11 +140,11 @@ class TestDataFlowGraph:
         assert len(df.pipelines) == 2
         assert "pipeline1" in df.pipelines
         assert "pipeline2" in df.pipelines
-
         pipeline1 = df.pipelines["pipeline1"]
         pipeline2 = df.pipelines["pipeline2"]
         assert len(pipeline1.nodes) == 4
         assert len(pipeline2.nodes) == 5
+        assert "output-topic" in pipeline1.nodes
         assert "output-topic" in pipeline2.nodes
 
         df.add_sink(Sink("test-sink", "output-topic"))

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -1,7 +1,7 @@
 import pytest
 
 from streams_explorer.core.config import settings
-from streams_explorer.core.k8s_app import K8sAppDeployment
+from streams_explorer.core.k8s_app import ATTR_PIPELINE, K8sAppDeployment
 from streams_explorer.core.services.dataflow_graph import DataFlowGraph
 from streams_explorer.core.services.metric_providers import MetricProvider
 from streams_explorer.models.kafka_connector import (
@@ -115,14 +115,14 @@ class TestDataFlowGraph:
                 pipeline="pipeline1",
             )
         )
-        assert df.graph.nodes["test-app1"].get("pipeline") == "pipeline1"
+        assert df.graph.nodes["test-app1"].get(ATTR_PIPELINE) == "pipeline1"
         df.add_streaming_app(
             self.get_k8s_app(
                 name="test-app2",
                 pipeline=None,
             )
         )
-        assert df.graph.nodes["test-app2"].get("pipeline") is None
+        assert df.graph.nodes["test-app2"].get(ATTR_PIPELINE) is None
 
     def test_pipeline_graph(self, df: DataFlowGraph):
         settings.k8s.pipeline.label = "pipeline"  # type: ignore

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -133,7 +133,7 @@ class TestDataFlowGraph:
                 pipeline="pipeline2",
             )
         )
-        df.extract_independent_pipelines()
+        # df.extract_independent_pipelines()
         assert "pipeline1" in df.pipelines
         assert "pipeline2" in df.pipelines
         assert len(df.pipelines) == 2

--- a/backend/tests/test_streams_explorer.py
+++ b/backend/tests/test_streams_explorer.py
@@ -183,9 +183,7 @@ class TestStreamsExplorer:
     def test_get_pipeline_names(self, streams_explorer):
         streams_explorer.update()
         assert streams_explorer.get_pipeline_names() == [
-            "streaming-app1",
             "pipeline2",
-            "generic-source-connector",
         ]
 
     def test_get_node_information(self, streams_explorer, monkeypatch):

--- a/backend/tests/utils.py
+++ b/backend/tests/utils.py
@@ -12,6 +12,8 @@ from kubernetes.client import (
     V1StatefulSetSpec,
 )
 
+from streams_explorer.core.k8s_app import ATTR_PIPELINE
+
 
 def get_streaming_app_deployment(
     name,
@@ -81,7 +83,7 @@ def get_metadata(name, pipeline=None) -> V1ObjectMeta:
             "app_name": "test-app-name",
             "chart": "streams-app-0.1.0",
             "release": "test-release",
-            "pipeline": pipeline,
+            ATTR_PIPELINE: pipeline,
         },
         name="test-app-name",
         namespace="test-namespace",


### PR DESCRIPTION
Create independent pipeline graphs directly from label. This eliminates the need to split it out from the entire graph in a later step. 
Pipelines should be named correctly, without being split or joined as it could happen previously.

For connectors, sinks, and sources the associated pipeline is assigned by checking connected nodes in their neighbourhood.