### PR TITLE
Improve error handling

### DIFF
--- a/backend/streams_explorer/api/routes/graph.py
+++ b/backend/streams_explorer/api/routes/graph.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from fastapi import APIRouter, Depends
+from fastapi.exceptions import HTTPException
 
 from streams_explorer.api.dependencies.streams_explorer import (
     get_streams_explorer_from_request,
@@ -17,5 +18,10 @@ async def graph_positioned(
     streams_explorer: StreamsExplorer = Depends(get_streams_explorer_from_request),
 ):
     if pipeline_name:
-        return streams_explorer.get_positioned_pipeline_json_graph(pipeline_name)
+        pipeline_graph = streams_explorer.get_positioned_pipeline_json_graph(
+            pipeline_name
+        )
+        if not pipeline_graph:
+            raise HTTPException(status_code=404, detail="Pipeline not found")
+        return pipeline_graph
     return streams_explorer.get_positioned_json_graph()

--- a/backend/streams_explorer/api/routes/graph.py
+++ b/backend/streams_explorer/api/routes/graph.py
@@ -22,6 +22,8 @@ async def graph_positioned(
             pipeline_name
         )
         if not pipeline_graph:
-            raise HTTPException(status_code=404, detail="Pipeline not found")
+            raise HTTPException(
+                status_code=404, detail=f"Pipeline '{pipeline_name}' not found"
+            )
         return pipeline_graph
     return streams_explorer.get_positioned_json_graph()

--- a/backend/streams_explorer/api/routes/graph.py
+++ b/backend/streams_explorer/api/routes/graph.py
@@ -21,7 +21,7 @@ async def graph_positioned(
         pipeline_graph = streams_explorer.get_positioned_pipeline_json_graph(
             pipeline_name
         )
-        if not pipeline_graph:
+        if pipeline_graph is None:
             raise HTTPException(
                 status_code=404, detail=f"Pipeline '{pipeline_name}' not found"
             )

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -117,10 +117,10 @@ class DataFlowGraph:
                 self.pipelines[pipeline].add_node(node_name, **node_data)
                 self.pipelines[pipeline].add_edge(*edge)
 
-    def get_positioned_pipeline_graph(self, pipeline_name: str) -> dict:
-        if pipeline_name in self.pipelines:
-            return self.__get_positioned_json_graph(self.pipelines[pipeline_name])
-        return {}
+    def get_positioned_pipeline_graph(self, pipeline_name: str) -> Optional[dict]:
+        if pipeline_name not in self.pipelines:
+            return None
+        return self.__get_positioned_json_graph(self.pipelines[pipeline_name])
 
     def get_positioned_graph(self) -> dict:
         return self.__get_positioned_json_graph(self.graph)

--- a/backend/streams_explorer/core/services/dataflow_graph.py
+++ b/backend/streams_explorer/core/services/dataflow_graph.py
@@ -118,7 +118,9 @@ class DataFlowGraph:
                 self.pipelines[pipeline].add_edge(*edge)
 
     def get_positioned_pipeline_graph(self, pipeline_name: str) -> dict:
-        return self.__get_positioned_json_graph(self.pipelines[pipeline_name])
+        if pipeline_name in self.pipelines:
+            return self.__get_positioned_json_graph(self.pipelines[pipeline_name])
+        return {}
 
     def get_positioned_graph(self) -> dict:
         return self.__get_positioned_json_graph(self.graph)

--- a/backend/streams_explorer/streams_explorer.py
+++ b/backend/streams_explorer/streams_explorer.py
@@ -52,7 +52,7 @@ class StreamsExplorer:
     def get_positioned_json_graph(self) -> dict:
         return self.data_flow.get_positioned_graph()
 
-    def get_positioned_pipeline_json_graph(self, pipeline_name: str) -> dict:
+    def get_positioned_pipeline_json_graph(self, pipeline_name: str) -> Optional[dict]:
         return self.data_flow.get_positioned_pipeline_graph(pipeline_name)
 
     def get_pipeline_names(self) -> List[str]:

--- a/backend/streams_explorer/streams_explorer.py
+++ b/backend/streams_explorer/streams_explorer.py
@@ -52,7 +52,7 @@ class StreamsExplorer:
     def get_positioned_json_graph(self) -> dict:
         return self.data_flow.get_positioned_graph()
 
-    def get_positioned_pipeline_json_graph(self, pipeline_name) -> dict:
+    def get_positioned_pipeline_json_graph(self, pipeline_name: str) -> dict:
         return self.data_flow.get_positioned_pipeline_graph(pipeline_name)
 
     def get_pipeline_names(self) -> List[str]:

--- a/backend/tests/test_application.py
+++ b/backend/tests/test_application.py
@@ -32,6 +32,10 @@ class TestApplication:
         assert response.headers["content-type"] == "text/plain; charset=utf-8"
         assert response.content.decode() == ""
 
+    def test_pipeline_not_found(self, client: TestClient):
+        response = client.get("/graph", params="pipeline=doesnt-exist")
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
     @pytest.mark.asyncio
     async def test_update_every_x_seconds(self, mocker, monkeypatch):
         # workaround for exception "This event loop is already running"

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -21,7 +21,7 @@ class TestDataFlowGraph:
         return DataFlowGraph(metric_provider=MetricProvider)
 
     def test_positioned_pipeline_graph_not_found(self, df: DataFlowGraph):
-        assert df.get_positioned_pipeline_graph("doesnt-exist") == {}
+        assert df.get_positioned_pipeline_graph("doesnt-exist") is None
 
     def test_add_streaming_app(self, df: DataFlowGraph):
         df.add_streaming_app(K8sApp.factory(get_streaming_app_deployment()))

--- a/backend/tests/test_dataflow_graph.py
+++ b/backend/tests/test_dataflow_graph.py
@@ -20,6 +20,9 @@ class TestDataFlowGraph:
     def df(self) -> DataFlowGraph:
         return DataFlowGraph(metric_provider=MetricProvider)
 
+    def test_positioned_pipeline_graph_not_found(self, df: DataFlowGraph):
+        assert df.get_positioned_pipeline_graph("doesnt-exist") == {}
+
     def test_add_streaming_app(self, df: DataFlowGraph):
         df.add_streaming_app(K8sApp.factory(get_streaming_app_deployment()))
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#383838" />
+    <meta name="theme-color" content="#323232" />
     <meta name="description" content="Streams Explorer" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#001529" />
+    <meta name="theme-color" content="#383838" />
     <meta name="description" content="Streams Explorer" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -12,6 +12,11 @@ body {
   min-height: 100vh;
 }
 
+.ant-menu,
+.ant-layout-header {
+  background: #383838 !important;
+}
+
 .header {
   position: fixed;
   z-index: 1;

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -380,6 +380,10 @@ describe("Streams Explorer", () => {
       });
 
       expect(getByTestId("location-pathname")).toHaveTextContent("/");
+      expect(getByTestId("location-search")).toHaveTextContent("");
+
+      history.goBack();
+      expect(getByTestId("location-pathname")).toHaveTextContent("/");
       expect(getByTestId("location-search")).toHaveTextContent(
         "?pipeline=doesnt-exist"
       );

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -328,6 +328,40 @@ describe("Streams Explorer", () => {
         );
       });
     });
+
+    it("should redirect to all pipelines if pipeline is not found", async () => {
+      const nockPipeline = nock("http://localhost")
+        .get(`/api/graph?pipeline_name=doesnt-exist`)
+        .reply(404);
+
+      history.push({ pathname: "/", search: "?pipeline=doesnt-exist" });
+
+      const { getByTestId } = render(
+        <RestfulProvider base="http://localhost">
+          <Router history={history}>
+            <LocationDisplay />
+            <App />
+          </Router>
+        </RestfulProvider>
+      );
+
+      expect(getByTestId("location-pathname")).toHaveTextContent("/");
+      expect(getByTestId("location-search")).toHaveTextContent(
+        "?pipeline=doesnt-exist"
+      );
+
+      await waitForElement(() => getByTestId("graph"));
+      // const errorMessage = await waitForElement(() =>
+      //   findByText("Failed loading graph")
+      // );
+      // expect(message.error).toHaveBeenCalledTimes(1);
+
+      const currentPipeline = getByTestId("pipeline-current");
+      expect(
+        within(currentPipeline).getByText("all pipelines")
+      ).toBeInTheDocument();
+      expect(nockPipeline.isDone()).toBeTruthy();
+    });
   });
 });
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -150,7 +150,7 @@ const App: React.FC = () => {
 
       if (graphError.status === 404 && currentPipeline !== ALL_PIPELINES) {
         // check if a re-scrape solves it
-        const hideMessage = message.warning("Scraping cluster", 0);
+        const hideMessage = message.warning("Refreshing pipelines", 0);
         update({})
           .then(() => {
             retryPipelineGraph();
@@ -182,6 +182,7 @@ const App: React.FC = () => {
   const redirectAllPipelines = () => {
     message.info("Redirecting to all pipelines");
     setCurrentPipeline(ALL_PIPELINES);
+    history.push("/");
   };
 
   useEffect(() => {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,6 +3,7 @@ import {
   usePipelinesApiPipelinesGet,
   useGraphPositionedApiGraphGet,
   useMetricsApiMetricsGet,
+  HTTPValidationError,
 } from "./api/fetchers";
 import DetailsCard from "./components/DetailsCard";
 import GraphVisualization from "./components/GraphVisualization";
@@ -128,16 +129,15 @@ const App: React.FC = () => {
   useEffect(() => {
     if (graphError) {
       if ("data" in graphError) {
-        message.error(graphError["data"]["detail"], 5);
+        const data = graphError["data"] as HTTPValidationError;
+        message.error(data.detail, 5);
       } else {
         message.error("Failed loading graph");
       }
 
-      if (graphError.status === 404) {
+      if (graphError.status === 404 && currentPipeline !== ALL_PIPELINES) {
         // Redirect to all pipelines
-        if (currentPipeline !== ALL_PIPELINES) {
-          setCurrentPipeline(ALL_PIPELINES);
-        }
+        setCurrentPipeline(ALL_PIPELINES);
       }
     }
   }, [graphError]); // eslint-disable-line react-hooks/exhaustive-deps

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -125,26 +125,34 @@ const App: React.FC = () => {
     }
   }, [getParams, location]);
 
-  if (graphError) {
-    if (typeof graphError.data === "object") {
-      message.error(graphError.data.detail, 5);
-    } else {
-      message.error("Failed loading graph");
-    }
+  useEffect(() => {
+    if (graphError) {
+      if (typeof graphError.errorData === "object") {
+        message.error(graphError.errorData.detail, 5);
+      } else {
+        message.error("Failed loading graph");
+      }
 
-    if (graphError.status === 404) {
-      // Redirect to all pipelines
-      if (currentPipeline !== ALL_PIPELINES) {
-        setCurrentPipeline(ALL_PIPELINES);
+      if (graphError.status === 404) {
+        // Redirect to all pipelines
+        if (currentPipeline !== ALL_PIPELINES) {
+          setCurrentPipeline(ALL_PIPELINES);
+        }
       }
     }
-  }
-  if (metricsError) {
-    message.warning("Failed fetching metrics");
-  }
-  if (pipelineError) {
-    message.error(pipelineError.message);
-  }
+  }, [graphError]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  useEffect(() => {
+    if (metricsError) {
+      message.warning("Failed fetching metrics");
+    }
+  }, [metricsError]);
+
+  useEffect(() => {
+    if (pipelineError) {
+      message.error(pipelineError.message);
+    }
+  }, [pipelineError]);
 
   const menuPipeline = (
     <Menu

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -134,10 +134,12 @@ const App: React.FC = () => {
   useEffect(() => {
     if (graphError) {
       let errorMessage: string | undefined;
-      if ("data" in graphError && graphError["data"]["detail"]) {
+      if ("data" in graphError) {
+        // specific pipeline was not found
         const data = graphError["data"] as HTTPValidationError;
-        // Couldn't find pipeline xy
-        errorMessage = data.detail?.toString();
+        if (data.detail) {
+          errorMessage = data.detail.toString();
+        }
       }
       message.error(errorMessage || "Failed loading graph", 5);
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -75,6 +75,7 @@ const App: React.FC = () => {
   const { refetch: retryPipelineGraph, error: retryPipelineGraphError } =
     useGraphPositionedApiGraphGet({
       queryParams: { pipeline_name: currentPipeline },
+      lazy: true,
     });
 
   const {
@@ -163,17 +164,16 @@ const App: React.FC = () => {
   }, [graphError]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const checkRetryResult = () => {
-    if (retryPipelineGraphError) {
-      if (
-        retryPipelineGraphError.status === 404 &&
-        currentPipeline !== ALL_PIPELINES
-      ) {
-        // Pipeline still not found
-        redirectAllPipelines();
-      } else {
-        message.success("Found pipeline!");
-        window.location.reload();
-      }
+    if (
+      !retryPipelineGraphError ||
+      (retryPipelineGraphError.status === 404 &&
+        currentPipeline !== ALL_PIPELINES)
+    ) {
+      // Pipeline still not found
+      redirectAllPipelines();
+    } else {
+      message.success("Found pipeline!");
+      window.location.reload();
     }
   };
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -77,9 +77,12 @@ const App: React.FC = () => {
     error: pipelineError,
   } = usePipelinesApiPipelinesGet({});
 
-  const { data: metrics, refetch: refetchMetrics } = useMetricsApiMetricsGet(
-    {}
-  );
+  const {
+    data: metrics,
+    loading: isLoadingMetrics,
+    refetch: refetchMetrics,
+    error: metricsError,
+  } = useMetricsApiMetricsGet({});
 
   const getParams = useCallback(() => {
     return new URLSearchParams(location.search);
@@ -123,17 +126,24 @@ const App: React.FC = () => {
   }, [getParams, location]);
 
   if (graphError) {
-    message.error(graphError.message);
-    return (
-      <Spin
-        data-testid="graph-error"
-        spinning={false}
-        tip="Failed to load graph"
-      />
-    );
+    if (typeof graphError.data === "object") {
+      message.error(graphError.data.detail, 5);
+    } else {
+      message.error("Failed loading graph");
+    }
+
+    if (graphError.status === 404) {
+      // Redirect to all pipelines
+      if (currentPipeline !== ALL_PIPELINES) {
+        setCurrentPipeline(ALL_PIPELINES);
+      }
+    }
+  }
+  if (metricsError) {
+    message.warning("Failed fetching metrics");
   }
   if (pipelineError) {
-    message.error(pipelineError?.message);
+    message.error(pipelineError.message);
   }
 
   const menuPipeline = (

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -244,10 +244,6 @@ const App: React.FC = () => {
                     {refreshIntervals[refreshInterval]} <DownOutlined />
                   </a>
                 </Dropdown>
-                <Spin
-                  indicator={<LoadingOutlined spin />}
-                  spinning={isLoadingMetrics}
-                />
               </Menu.Item>
               <Menu.Item
                 style={{ float: "right" }}
@@ -262,6 +258,15 @@ const App: React.FC = () => {
                 </Button>
               </Menu.Item>
             </Menu>
+            <Spin
+              style={{
+                position: "fixed",
+                top: "1.5em",
+                right: "1em",
+              }}
+              indicator={<LoadingOutlined spin />}
+              spinning={isLoadingMetrics}
+            />
           </Header>
           <Content
             style={{

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,8 +17,8 @@ import {
   Spin,
   message,
   Alert,
+  AutoComplete,
 } from "antd";
-import { AutoComplete } from "antd";
 import React, { useState, useRef, useEffect, useCallback } from "react";
 import { useResizeDetector } from "react-resize-detector";
 import { useMutate } from "restful-react";

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -143,12 +143,6 @@ const App: React.FC = () => {
   }, [graphError]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
-    if (isLoadingMetrics) {
-      message.loading("Refreshing metrics...", () => isLoadingMetrics);
-    }
-  }, [isLoadingMetrics]);
-
-  useEffect(() => {
     if (metricsError) {
       message.warning("Failed fetching metrics");
     }

--- a/frontend/src/__snapshots__/App.test.tsx.snap
+++ b/frontend/src/__snapshots__/App.test.tsx.snap
@@ -222,6 +222,30 @@ exports[`Streams Explorer handles url parameters should set pipeline from url pa
             </div>
           </li>
         </ul>
+        <div
+          class="ant-spin"
+          style="position: fixed; top: 1.5em; right: 1em;"
+        >
+          <span
+            aria-label="loading"
+            class="anticon anticon-loading anticon-spin ant-spin-dot"
+            role="img"
+          >
+            <svg
+              aria-hidden="true"
+              data-icon="loading"
+              fill="currentColor"
+              focusable="false"
+              height="1em"
+              viewBox="0 0 1024 1024"
+              width="1em"
+            >
+              <path
+                d="M988 548c-19.9 0-36-16.1-36-36 0-59.4-11.6-117-34.6-171.3a440.45 440.45 0 00-94.3-139.9 437.71 437.71 0 00-139.9-94.3C629 83.6 571.4 72 512 72c-19.9 0-36-16.1-36-36s16.1-36 36-36c69.1 0 136.2 13.5 199.3 40.3C772.3 66 827 103 874 150c47 47 83.9 101.8 109.7 162.7 26.7 63.1 40.2 130.2 40.2 199.3.1 19.9-16 36-35.9 36z"
+              />
+            </svg>
+          </span>
+        </div>
       </header>
       <main
         class="ant-layout-content"
@@ -247,7 +271,7 @@ exports[`Streams Explorer handles url parameters should set pipeline from url pa
             >
               <div
                 class="ant-card-head"
-                style="background-color: rgb(74, 78, 77); color: white;"
+                style="background-color: rgb(56, 56, 56); color: white;"
               >
                 <div
                   class="ant-card-head-wrapper"

--- a/frontend/src/components/DetailsCard.tsx
+++ b/frontend/src/components/DetailsCard.tsx
@@ -17,7 +17,7 @@ const DetailsCard = ({ nodeID }: DetailsCardProps) => {
         title={nodeID ? `${nodeID} - Details` : "Click on Node  to see Details"}
         bodyStyle={{}}
         style={{ width: width }}
-        headStyle={{ backgroundColor: "#4a4e4d", color: "white" }}
+        headStyle={{ backgroundColor: "#383838", color: "white" }}
       >
         {nodeID ? <Details nodeID={nodeID} /> : null}
       </Card>


### PR DESCRIPTION
Closes #116 
Closes #131 

- Raise a 404 if pipeline doesnt exist
- Show descriptive error message in frontend
- Triggers an update in backend (re-scrape Kubernetes cluster) if specific pipeline from url parameter doesn't exist
- Refresh if pipeline is found
- Redirect to all pipelines if specific pipeline still doesn't exist
- also added a loading indicator for when metrics are being refreshed

todo:

- [x] investigate duplicate errors
- [x] add backend test
- [x] add frontend tests

~~idea: perhaps display a persistent popup with choices "Update pipelines" and "Back to all pipelines"~~

- [x] update frontend tests for retry logic