### PR TITLE
Mention Karapace support in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - [Configuration](#configuration)
     - [Kafka Connect](#kafka-connect)
     - [Kubernetes](#kubernetes)
-    - [Schema Registry / Karapace](#schema-registry---karapace)
+    - [Schema Registry / Karapace](#schema-registry--karapace)
     - [Prometheus](#prometheus)
     - [AKHQ](#akhq)
     - [Kowl](#kowl)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - [Configuration](#configuration)
     - [Kafka Connect](#kafka-connect)
     - [Kubernetes](#kubernetes)
-    - [Schema Registry](#schema-registry)
+    - [Schema Registry](#schema-registry---karapace)
     - [Prometheus](#prometheus)
     - [AKHQ](#akhq)
     - [Kowl](#kowl)
@@ -138,9 +138,9 @@ The following configuration options are available:
 - `k8s.pipeline.label` Attribute of nodes the pipeline name should be extracted from (string, **required**, default: `pipeline`)
 - `k8s.consumer_group_annotation` Annotation the consumer group name should be extracted from (string, **required**, default: `consumerGroup`)
 
-#### Schema Registry
+#### Schema Registry / Karapace
 
-- `schemaregistry.url` URL of Schema Registry (string, default: None)
+- `schemaregistry.url` URL of Schema Registry or Karapace (string, default: None)
 
 #### Prometheus
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   - [Configuration](#configuration)
     - [Kafka Connect](#kafka-connect)
     - [Kubernetes](#kubernetes)
-    - [Schema Registry](#schema-registry---karapace)
+    - [Schema Registry / Karapace](#schema-registry---karapace)
     - [Prometheus](#prometheus)
     - [AKHQ](#akhq)
     - [Kowl](#kowl)

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The following configuration options are available:
 
 #### Schema Registry / Karapace
 
-- `schemaregistry.url` URL of Schema Registry or Karapace (string, default: None)
+- `schemaregistry.url` URL of Confluent Schema Registry or Karapace (string, default: None)
 
 #### Prometheus
 

--- a/backend/settings.yaml
+++ b/backend/settings.yaml
@@ -26,14 +26,14 @@ k8s:
     # refers to the attribute of nodes the pipeline name should be extracted from
     label: "pipeline"
 
-## (optional) configure kafka connect url and displayed information
+## (optional) configure Kafka Connect url and displayed information
 # kafkaconnect:
 #   url: "http://localhost:8083"
 #   displayed_information:
 #     - name: "Transformer"
 #       key: "transforms.changeTopic.regex"
 
-## (optional) configure schema registry for topic information
+## (optional) configure Schema Registry for topic information (supports Karapace and Confluent Schema Registry)
 # schemaregistry:
 #   url: "http://localhost:8081"
 


### PR DESCRIPTION
Closes #159

Karapace serves as a drop-in replacement for Schema Registry.
Since the API which we use is identical, we already support it.
