### PR TITLE
Improve settings validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ The following configuration options are available:
 
 #### Kafka
 
-- `kafka.enable` Enable Kafka (bool, **required**, default: `false`)
-- `kafka.config` librdkafka configuration properties ([reference](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)) (dict, **required**, default: `{"bootstrap.servers": "localhost:9092"}`)
+- `kafka.enable` Enable Kafka (bool, default: `false`)
+- `kafka.config` librdkafka configuration properties ([reference](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md)) (dict, default: `{"bootstrap.servers": "localhost:9092"}`)
 - `kafka.displayed_information` Configuration options of Kafka topics displayed in the frontend (list of dict)
 
 #### Kafka Connect
@@ -161,7 +161,7 @@ The following exporters are required to collect Kafka metrics for Prometheus:
 
 #### AKHQ
 
-- `akhq.enable` Enable AKHQ (bool, **required**, default: `false`)
+- `akhq.enable` Enable AKHQ (bool, default: `false`)
 - `akhq.url` URL of AKHQ (string, default: `http://localhost:8080`)
 - `akhq.cluster` Name of cluster (string, default: `kubernetes-cluster`)
 - `akhq.connect` Name of connect (string, default: None)
@@ -170,7 +170,7 @@ The following exporters are required to collect Kafka metrics for Prometheus:
 
 Kowl can be used instead of AKHQ. (mutually exclusive)
 
-- `kowl.enable` Enable Kowl (bool, **required**, default: `false`)
+- `kowl.enable` Enable Kowl (bool, default: `false`)
 - `kowl.url` URL of Kowl (string, default: `http://localhost:8080`)
 
 #### Grafana
@@ -181,14 +181,14 @@ Kowl can be used instead of AKHQ. (mutually exclusive)
 
 #### Kibana
 
-- `kibanalogs.enable` Enable Kibana logs (bool, **required**, default: `false`)
+- `kibanalogs.enable` Enable Kibana logs (bool, default: `false`)
 - `kibanalogs.url` URL of Kibana logs (string, default: `http://localhost:5601`)
 
 #### Loki
 
 Loki can be used instead of Kibana. (mutually exclusive)
 
-- `loki.enable` Enable Loki logs (bool, **required**, default: `false`)
+- `loki.enable` Enable Loki logs (bool, default: `false`)
 - `loki.url` URL of Loki logs (string, default: `http://localhost:3000`)
 
 #### Elasticsearch

--- a/backend/streams_explorer/core/config.py
+++ b/backend/streams_explorer/core/config.py
@@ -1,11 +1,11 @@
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from dynaconf import Dynaconf, Validator
 
 APP_NAME = "Streams Explorer"
 API_PREFIX = "/api"
 
-settings = Dynaconf(
+settings: Any = Dynaconf(
     envvar_prefix="se",
     settings_files=["settings.yaml"],
     load_dotenv=True,

--- a/backend/streams_explorer/core/config.py
+++ b/backend/streams_explorer/core/config.py
@@ -20,15 +20,17 @@ settings = Dynaconf(
         Validator("k8s.labels", must_exist=True, is_type_of=list),
         Validator("k8s.pipeline.label", must_exist=True, is_type_of=str),
         Validator("k8s.consumer_group_annotation", must_exist=True, is_type_of=str),
-        Validator("kafka.enable", must_exist=True, eq=False)
-        | Validator("kafka.enable", must_exist=True, eq=True)
-        & Validator(
-            "kafka.config",
-            must_exist=True,
-            is_type_of=dict,
-            condition=lambda v: type(v.get("bootstrap.servers")) is str,
-        )
-        & Validator("kafka.displayed_information", is_type_of=list, default=[]),
+        Validator("kafka.enable", eq=False, default=False)
+        | (
+            Validator("kafka.enable", eq=True)
+            & Validator(
+                "kafka.config",
+                is_type_of=dict,
+                must_exist=True,
+                condition=lambda v: type(v.get("bootstrap.servers")) is str,
+            )
+        ),
+        Validator("kafka.displayed_information", is_type_of=list, default=[]),
         Validator("node_info.cache_ttl", must_exist=True, is_type_of=int),
         Validator("kafkaconnect.url", default=None),
         Validator("kafkaconnect.displayed_information", is_type_of=list, default=[]),

--- a/backend/streams_explorer/core/config.py
+++ b/backend/streams_explorer/core/config.py
@@ -20,14 +20,15 @@ settings = Dynaconf(
         Validator("k8s.labels", must_exist=True, is_type_of=list),
         Validator("k8s.pipeline.label", must_exist=True, is_type_of=str),
         Validator("k8s.consumer_group_annotation", must_exist=True, is_type_of=str),
-        Validator("kafka.enable", must_exist=True, is_type_of=bool),
-        Validator(
+        Validator("kafka.enable", must_exist=True, eq=False)
+        | Validator("kafka.enable", must_exist=True, eq=True)
+        & Validator(
             "kafka.config",
             must_exist=True,
             is_type_of=dict,
             condition=lambda v: type(v.get("bootstrap.servers")) is str,
-        ),
-        Validator("kafka.displayed_information", is_type_of=list, default=[]),
+        )
+        & Validator("kafka.displayed_information", is_type_of=list, default=[]),
         Validator("node_info.cache_ttl", must_exist=True, is_type_of=int),
         Validator("kafkaconnect.url", default=None),
         Validator("kafkaconnect.displayed_information", is_type_of=list, default=[]),
@@ -35,11 +36,11 @@ settings = Dynaconf(
         Validator("prometheus.url", must_exist=True, is_type_of=str),
         Validator("grafana.dashboards.topics", is_type_of=str),
         Validator("grafana.dashboards.consumergroups", is_type_of=str),
-        Validator("akhq.enable", is_type_of=bool),
-        Validator("kowl.enable", is_type_of=bool),
+        Validator("akhq.enable", is_type_of=bool, default=False),
+        Validator("kowl.enable", is_type_of=bool, default=False),
         Validator("akhq.enable", eq=False) | Validator("kowl.enable", eq=False),
-        Validator("kibanalogs.enable", is_type_of=bool),
-        Validator("loki.enable", is_type_of=bool),
+        Validator("kibanalogs.enable", is_type_of=bool, default=False),
+        Validator("loki.enable", is_type_of=bool, default=False),
         Validator("kibanalogs.enable", eq=False) | Validator("loki.enable", eq=False),
         Validator("plugins.path", must_exist=True, is_type_of=str),
         Validator("plugins.extractors.default", must_exist=True, is_type_of=bool),

--- a/backend/tests/test_extractors.py
+++ b/backend/tests/test_extractors.py
@@ -60,8 +60,12 @@ EMPTY_CONNECTOR_INFO = {"config": {}, "type": ""}
 
 class TestExtractors:
     @pytest.fixture(autouse=True)
-    def kafka_connect(self):
+    def setup_teardown(self):
+        # setup
         settings.kafkaconnect.url = "testurl:3000"
+        yield  # testing
+        # teardown
+        settings.plugins.path = "./plugins"
 
     def test_load_extractors(self):
         settings.plugins.extractors.default = True

--- a/backend/tests/test_kafka.py
+++ b/backend/tests/test_kafka.py
@@ -12,10 +12,12 @@ test_topic = "test-topic"
 
 
 class TestKafka:
-    def test_kafka_settings(self):
+    def test_settings(self):
+        # validate default
         settings.kafka.enable = True
         settings.validators.validate()
 
+        # should fail if no broker is set
         settings.kafka.config = {"bootstrap.servers": None}
         with pytest.raises(ValidationError):
             settings.validators.validate()


### PR DESCRIPTION
- Set optional integrations to disabled by default
- Allow kafka settings to be optional (defaults to disabled)
- Add tests for kafka settings validation
- Avoid Pyright errors reported for all dynaconf settings
