### PR TITLE
Build image using standard Python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # build stage 1: frontend
-FROM node:16 AS builder
+FROM node:16 AS frontend
 
 WORKDIR /build
 COPY ./frontend/package.json ./frontend/package-lock.json /build/
@@ -10,13 +10,13 @@ COPY ./frontend /build
 RUN npm run build --prefix /build
 
 # build stage 2: backend
-FROM tiangolo/uvicorn-gunicorn-fastapi:python3.9-slim
-
-COPY --from=builder /build/out /app/static
+FROM python:3.9-slim
 
 RUN apt-get -y update && \
     apt-get --no-install-recommends -y install gcc python3-dev graphviz libgraphviz-dev pkg-config && \
     rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
 
 COPY ./backend/pyproject.toml ./backend/poetry.lock /app/
 ENV PIP_NO_CACHE_DIR=1
@@ -26,3 +26,7 @@ RUN pip install -U pip poetry && \
 COPY ./backend /app
 
 RUN apt-get -y purge --auto-remove -o APT::AutoRemove::RecommendsImportant=false
+
+COPY --from=frontend /build/out /app/static
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,4 +29,6 @@ RUN apt-get -y purge --auto-remove -o APT::AutoRemove::RecommendsImportant=false
 
 COPY --from=frontend /build/out /app/static
 
+EXPOSE 80
+
 CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM node:16 AS frontend
 WORKDIR /build
 COPY ./frontend/package.json ./frontend/package-lock.json /build/
 ENV NODE_ENV=production
-RUN npm ci --prefix /build
+RUN npm ci
 
 COPY ./frontend /build
 RUN npm run build

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV NODE_ENV=production
 RUN npm ci --prefix /build
 
 COPY ./frontend /build
-RUN npm run build --prefix /build
+RUN npm run build
 
 # build stage 2: backend
 FROM python:3.9-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,4 +31,4 @@ COPY --from=frontend /build/out /app/static
 
 EXPOSE 80
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "80"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "80"]

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -22,8 +22,6 @@ config:
 #   ...
 
 envPrefix: "SE_"
-env:
-  MAX_WORKERS: "1" # Max number of FastAPI worker processes inside the pod
 
 # Configure secret env variables here
 secrets: {}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -94,6 +94,7 @@ health:
   readinessProbeTimeout: 30
   readinessProbeFailureThreshold: 3
   readinessProbeSuccessThreshold: 1
+
 # nodeAffinity:
 #   requiredDuringSchedulingIgnoredDuringExecution:
 #     nodeSelectorTerms:


### PR DESCRIPTION
Since we're deploying to Kubernetes, we don't need Gunicorn to scale the amount of Uvicorn workers. So far we set `MAX_WORKERS=1`, but we could scale using replicas if we need more workers.

https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker#-warning-you-probably-dont-need-this-docker-image