### PR TITLE
Retrieve package version dynamically

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -6,7 +6,3 @@ tag = True
 [bumpversion:file:backend/pyproject.toml]
 search = version = "{current_version}"
 replace = version = "{new_version}"
-
-[bumpversion:file:backend/streams_explorer/__init__.py]
-search = __version__ = "{current_version}"
-replace = __version__ = "{new_version}"

--- a/backend/streams_explorer/__init__.py
+++ b/backend/streams_explorer/__init__.py
@@ -1,2 +1,4 @@
 """Streams Explorer."""
-__version__ = "1.4.4"
+import importlib.metadata
+
+__version__ = importlib.metadata.version(__name__)


### PR DESCRIPTION
This allows us to remove the bumpversion logic for updating `__version__`. It's also the first step towards replacing bumpversion with poetry version.
