### PR TITLE
Set Python version to 3.9 for PyPI publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,14 +25,6 @@ jobs:
       - name: Install packages
         run: sudo apt-get -y install python3-dev graphviz libgraphviz-dev pkg-config python3-wheel
 
-      - name: Release to TestPyPI
-        uses: bakdata/ci-templates/actions/python-poetry-release@v1.0.0
-        with:
-          python-version: ${{ env.python-version }}
-          working-directory: ${{ env.BACKEND_DIR }}
-          pypi-token: ${{ secrets.test-pypi-token }}
-          publish-to-test: "true"
-
       - name: Release to PyPI
         uses: bakdata/ci-templates/actions/python-poetry-release@v1.0.0
         with:


### PR DESCRIPTION
Workaround for https://github.com/bakdata/ci-templates/issues/18