### PR TITLE
Skip Python setup for frontend CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,8 @@ jobs:
       - name: Lint
         run: npm run lint
 
-      - name: Set up Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-
       - name: Install pre-commit
-        run: python -m pip install pre-commit
+        run: pipx install pre-commit
 
       - name: Formatting (dprint)
         run: pre-commit run dprint --all-files


### PR DESCRIPTION
We can use pipx to install pre-commit, that way we avoid having to setup Python for the frontend tests altogether.