### PR TITLE
Restart Kubernetes watch on status 410

### DIFF
--- a/backend/streams_explorer/core/services/kubernetes.py
+++ b/backend/streams_explorer/core/services/kubernetes.py
@@ -140,7 +140,7 @@ class Kubernetes:
                     async for event in stream:
                         await resource.callback(event)
         except ApiException as e:
-            if e.reason == "Expired":
+            if e.status == 410:
                 # restart watch to get fresh resource version
                 return await self.__watch_namespace(namespace, resource)
             else:


### PR DESCRIPTION
All `410 Gone` responses from Kubernetes API should restart the watch
