### PR TITLE
Restart Kubernetes watch after unauthorized error

### DIFF
--- a/backend/streams_explorer/core/services/kubernetes.py
+++ b/backend/streams_explorer/core/services/kubernetes.py
@@ -158,7 +158,7 @@ class Kubernetes:
                     async for event in stream:
                         await resource.callback(event)
         except ApiException as e:
-            logger.error(e)
+            logger.error("Kubernetes watch error {}", e)
             match e.status:
                 case 410:  # Expired
                     # parse resource version from error

--- a/backend/streams_explorer/core/services/kubernetes.py
+++ b/backend/streams_explorer/core/services/kubernetes.py
@@ -158,6 +158,7 @@ class Kubernetes:
                     async for event in stream:
                         await resource.callback(event)
         except ApiException as e:
+            logger.error(e)
             if e.status == 410:
                 # parse resource version from error
                 resource_version = None
@@ -175,4 +176,3 @@ class Kubernetes:
                 # restart watch to get fresh resource version
                 return await self.__watch_namespace(namespace, resource)
             raise e
-            # logger.error(e)

--- a/backend/streams_explorer/core/services/kubernetes.py
+++ b/backend/streams_explorer/core/services/kubernetes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import TYPE_CHECKING, Awaitable, Callable, NamedTuple, TypedDict
 
 import kubernetes_asyncio.client
@@ -146,19 +147,32 @@ class Kubernetes:
                 )
 
     async def __watch_namespace(
-        self,
-        namespace: str,
-        resource: K8sResource,
+        self, namespace: str, resource: K8sResource, resource_version: str | None = None
     ) -> None:
         return_type = resource.return_type.__name__ if resource.return_type else None
         try:
             async with kubernetes_asyncio.watch.Watch(return_type) as w:
-                async with w.stream(resource.func, namespace) as stream:
+                async with w.stream(
+                    resource.func, namespace, resource_version=resource_version
+                ) as stream:
                     async for event in stream:
                         await resource.callback(event)
         except ApiException as e:
             if e.status == 410:
+                # parse resource version from error
+                resource_version = None
+                if e.reason:
+                    match = re.match(
+                        r"Expired: too old resource version: \d+ \((\d+)\)", e.reason
+                    )
+
+                    if match:
+                        resource_version = match.group(1)
+                return await self.__watch_namespace(
+                    namespace, resource, resource_version
+                )
+            if e.status == 401:
                 # restart watch to get fresh resource version
                 return await self.__watch_namespace(namespace, resource)
-            else:
-                raise
+            raise e
+            # logger.error(e)

--- a/backend/streams_explorer/core/services/kubernetes.py
+++ b/backend/streams_explorer/core/services/kubernetes.py
@@ -147,7 +147,7 @@ class Kubernetes:
                 )
 
     async def __watch_namespace(
-        self, namespace: str, resource: K8sResource, resource_version: str | None = None
+        self, namespace: str, resource: K8sResource, resource_version: int | None = None
     ) -> None:
         return_type = resource.return_type.__name__ if resource.return_type else None
         try:
@@ -168,7 +168,7 @@ class Kubernetes:
                     )
 
                     if match:
-                        resource_version = match.group(1)
+                        resource_version = int(match.group(1))
                 return await self.__watch_namespace(
                     namespace, resource, resource_version
                 )

--- a/backend/tests/test_kubernetes.py
+++ b/backend/tests/test_kubernetes.py
@@ -14,16 +14,6 @@ def kubernetes() -> Kubernetes:
     return kubernetes
 
 
-# @pytest.fixture(autouse=True)
-# def sleep(mocker: MockFixture) -> None:
-#     async_mock = AsyncMock()
-#     # mocker.patch("asyncio.sleep", side_effect=async_mock)
-#     mocker.patch(
-#         "streams_explorer.core.services.kubernetes.asyncio.sleep",
-#         side_effect=async_mock,
-#     )
-
-
 @pytest.mark.asyncio
 async def test_watch(kubernetes: Kubernetes, mocker: MockFixture):
     mock_kubernetes_asyncio_watch = mocker.patch(

--- a/backend/tests/test_kubernetes.py
+++ b/backend/tests/test_kubernetes.py
@@ -182,7 +182,7 @@ async def test_watch_namespace_restart_expired_with_resource_version(
     mock_watch_namespace.assert_called_with(
         "test-namespace",
         K8sResource(mock_list_deployments, return_type=None, callback=mock_callback),
-        resource_version="987654321",
+        resource_version=987654321,
     )
 
 

--- a/backend/tests/test_kubernetes.py
+++ b/backend/tests/test_kubernetes.py
@@ -205,7 +205,7 @@ async def test_watch_namespace_restart_unauthorized(
     async def mock_callback() -> None:
         pass
 
-    # watch is restarting due to expired watch
+    # watch is restarting due to unauthorized error
     with pytest.raises(RecursionError) as e:
         await mock_watch_namespace(
             "test-namespace",


### PR DESCRIPTION
- restart Kubernetes watch after unauthorized error
- parse resource version from expired error
